### PR TITLE
Fixup: error message correction

### DIFF
--- a/src/dpkg.rs
+++ b/src/dpkg.rs
@@ -44,7 +44,7 @@ pub async fn print_architecture(args: &Args) -> Result<String> {
             .await?;
         if !exit.status.success() {
             bail!(
-                "Failed to query installed debian packages: exit={:?}",
+                "Failed to query native architecture: exit={:?}",
                 exit.status
             );
         }


### PR DESCRIPTION
Nitpicky correction for one of the `dpkg`-related error messages (noticed while planning to add a similar `print_foreign_architectures` function).