### PR TITLE
Refactor: raise check for command-line-supplied architecture

### DIFF
--- a/src/dpkg.rs
+++ b/src/dpkg.rs
@@ -32,26 +32,22 @@ impl FromStr for DpkgPackage {
     }
 }
 
-pub async fn print_architecture(args: &Args) -> Result<String> {
-    if let Some(arch) = &args.architecture {
-        Ok(arch.to_string())
-    } else {
-        let exit = Command::new("dpkg")
-            .args(["--print-architecture"])
-            .stdout(Stdio::piped())
-            .spawn()?
-            .wait_with_output()
-            .await?;
-        if !exit.status.success() {
-            bail!(
-                "Failed to query installed debian packages: exit={:?}",
-                exit.status
-            );
-        }
-        let output = exit.stdout.trim_ascii().to_owned();
-        let output = String::from_utf8(output)?;
-        Ok(output)
+pub async fn print_architecture() -> Result<String> {
+    let exit = Command::new("dpkg")
+        .args(["--print-architecture"])
+        .stdout(Stdio::piped())
+        .spawn()?
+        .wait_with_output()
+        .await?;
+    if !exit.status.success() {
+        bail!(
+            "Failed to query installed debian packages: exit={:?}",
+            exit.status
+        );
     }
+    let output = exit.stdout.trim_ascii().to_owned();
+    let output = String::from_utf8(output)?;
+    Ok(output)
 }
 
 pub async fn query_packages(args: &Args) -> Result<Vec<DpkgPackage>> {


### PR DESCRIPTION
When the `--architecture` flag is supplied on the command-line, we can consider that unrelated to `dpkg` functionality, I think -- so this changeset relocates that check back into the `main` module.

This is also partly to prepare for a potential side-by-side `print_foreign_archictures` function -- it'd be good for that to be consistent with `print_architecture` (e.g. neither of them would perform the command-line check).